### PR TITLE
Use hash for password

### DIFF
--- a/conf/attributes.yml
+++ b/conf/attributes.yml
@@ -118,6 +118,7 @@ password:
     weight: 31
     self: True
     type: password
+    hash: ldap_sha512_crypt
     backends:
         ldap: userPassword
 #        ad: unicodePwd

--- a/conf/attributes.yml
+++ b/conf/attributes.yml
@@ -118,7 +118,7 @@ password:
     weight: 31
     self: True
     type: password
-    hash: ldap_sha512_crypt
+#    hash: ldap_sha512_crypt
     backends:
         ldap: userPassword
 #        ad: unicodePwd

--- a/ldapcherry/__init__.py
+++ b/ldapcherry/__init__.py
@@ -31,6 +31,9 @@ from mako.template import Template
 from mako import lookup
 from sets import Set
 
+# passlib hash password module import
+from passlib.context import CryptContext
+
 SESSION_KEY = '_cp_username'
 
 
@@ -596,7 +599,12 @@ class LdapCherry(object):
                     raise PasswordMissMatch()
                 if not self._checkppolicy(params['attrs'][pwd1])['match']:
                     raise PPolicyError()
-                params['attrs'][attr] = params['attrs'][pwd1]
+                hash_type = self.attributes.attributes[attr].get('hash')
+                if hash_type:
+                    ctx = CryptContext(schemes=[hash_type])
+                    params['attrs'][attr] = ctx.encrypt(params['attrs'][pwd1])
+                else:
+                    params['attrs'][attr] = params['attrs'][pwd1]
             if attr in params['attrs']:
                 self.attributes.check_attr(attr, params['attrs'][attr])
                 backends = self.attributes.get_backends_attributes(attr)
@@ -653,7 +661,12 @@ class LdapCherry(object):
                                 params['attrs'][pwd1]
                                 )['match']:
                         raise PPolicyError()
-                    params['attrs'][attr] = params['attrs'][pwd1]
+                    hash_type = self.attributes.attributes[attr].get('hash')
+                    if hash_type:
+                        ctx = CryptContext(schemes=[hash_type])
+                        params['attrs'][attr] = ctx.encrypt(params['attrs'][pwd1])
+                    else:
+                        params['attrs'][attr] = params['attrs'][pwd1]
             if attr in params['attrs'] and params['attrs'][attr] != '':
                 self.attributes.check_attr(attr, params['attrs'][attr])
                 backends = self.attributes.get_backends_attributes(attr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ CherryPy>=3.0.0
 PyYAML
 Mako
 python-ldap
+passlib

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ if sys.version_info[0] == 2:
     install_requires = [
         'CherryPy >= 3.0.0',
         'python-ldap',
+        'passlib',
         'PyYAML',
         'Mako'
         ],


### PR DESCRIPTION
ldapcherry stores password as plaintext.
But, LDAP can store hashed password such as "{SHA1}xxxxxx" , "{CRYPT}xxxxxxx".

[passlib](https://pythonhosted.org/passlib/) can make hashed password easily.
This PR use this library.

By default, store password as plaintext.
If you configure password entry in attribute.yml with `hash: ldap_sha512_crypt` or other hash types, store password with specified hash.