### PR TITLE
adding support for display template parse error

### DIFF
--- a/ldapcherry/exceptions.py
+++ b/ldapcherry/exceptions.py
@@ -217,6 +217,11 @@ class GroupDoesntExist(Exception):
             " in backend '" + backend + "'"
 
 
+class TemplateRenderError(Exception):
+    def __init__(self, error):
+        self.log = "Template Render Error: " + error
+
+
 def exception_decorator(func):
     def ret(self, *args, **kwargs):
         try:


### PR DESCRIPTION
very useful when there is a syntax error in a maki template, this patch shows exact line