### PR TITLE
Protect against XSS vulnerabilities in URL redirection

### DIFF
--- a/resources/templates/adduser.tmpl
+++ b/resources/templates/adduser.tmpl
@@ -9,11 +9,11 @@
               <form method='POST' autocomplete="off" action='/adduser' role="form" class="form-signin" id=form>
               <fieldset>
               <legend>Fill new user's attributes:</legend>
-              ${form}
+              ${form | n}
               </fieldset>
               <fieldset>
               <legend>Enable/Disable user's roles:</legend>
-              ${roles}
+              ${roles | n}
               </fieldset>
               <div class="form-group">
                 <div class="input-group">

--- a/resources/templates/login.tmpl
+++ b/resources/templates/login.tmpl
@@ -4,13 +4,13 @@
     <div class="row clearfix" style="margin-top:30px">
         <div class="col-md-4 column"></div>
         <div class="col-md-4 column well">
-<%
-if url is None:
-    qs=''
-else:
-    qs='?url=' + url
-%>
-            <form method='POST' action='/login${qs}' role="form" class="form-signin">
+            <form method='POST' role="form" class="form-signin"
+% if url:
+                action='login?url=${url | u}'
+% else:
+                action='login'
+% endif
+            >
               <div class="form-group">
               <h2 class="form-signin-heading">Please sign in</h2>
                 <div class="input-group">

--- a/resources/templates/modify.tmpl
+++ b/resources/templates/modify.tmpl
@@ -9,11 +9,11 @@
               <form method='POST' action='/modify' role="form" class="form-signin" id="form">
               <fieldset>
               <legend>Modify user's attributes:</legend>
-              ${form}
+              ${form | n}
               </fieldset>
               <fieldset>
               <legend>Enable/Disable user's roles:</legend>
-              ${roles}
+              ${roles | n}
               </fieldset>
               % if len(standalone_groups) != 0:
               <fieldset>

--- a/resources/templates/selfmodify.tmpl
+++ b/resources/templates/selfmodify.tmpl
@@ -8,7 +8,7 @@
             <div class="well well-sm">
               <form method='POST' action='/selfmodify' autocomplete="off" role="form" class="form-signin" id="form">
               <legend>Modify your attributes:</legend>
-              ${form}
+              ${form | n}
               </fieldset>
               <div class="form-group">
                 <div class="input-group">


### PR DESCRIPTION
- Switch from base64 to URL encoding for the passing the URL, using the built-in Mako filtering
- Apply HTML filtering to Mako output by default
- Disable HTML filtering for nested templates in adduser, modify, and selfmodify