### PR TITLE
Change the email regular expression to fix a few validation issues

### DIFF
--- a/ldapcherry/attributes.py
+++ b/ldapcherry/attributes.py
@@ -71,7 +71,7 @@ class Attributes:
             raise MissingUserKey()
 
     def _is_email(self, email):
-        pattern = r'[\.\w]{1,}[@]\w+[.]\w+'
+        pattern = r'[\+\.\w]+@[-\.\w]+\.\w+'
         if re.match(pattern, email):
             return True
         else:


### PR DESCRIPTION
The current regexp used to validate emails is a bit flawed and rejects a few use case:

- hyphen in the domain part
- plus sign in the local part for subaddressing

There is also what I assume is an unescaped dot before the tld in the domain part, and a few intervals for single literal characters. I tried to fix the issues I had with it in this PR.