### PR TITLE
Fix default handler arguments

### DIFF
--- a/ldapcherry/__init__.py
+++ b/ldapcherry/__init__.py
@@ -1170,7 +1170,7 @@ class LdapCherry(object):
 
     @cherrypy.expose
     @exception_decorator
-    def default(self, attr='', **params):
+    def default(self, attr='', *args, **params):
         cherrypy.response.status = 404
         self._check_auth(must_admin=False)
         is_admin = self._check_admin()


### PR DESCRIPTION
The default handler is currently failing with the following error on CherryPy 18.1:

```
ldapcherry.app    - ERROR - [26/Mar/2019:09:19:15]  uncaught exception: [default() takes from 1 to 2 positional arguments but 4 were given]
```

This PR tries to fix this error.