### PR TITLE
Dockerize LdapCherry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tests/
+run_test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:16.04
 
-ADD . .
-RUN apt update && apt install -y python3 python3-pip && pip3 install -e . -r requirements.txt && pip3 install pycodestyle passlib coveralls && /usr/bin/python3 setup.py
+ADD . /opt/
+WORKDIR "/opt"
+RUN apt update && apt install -y python-dev python-pip libldap2-dev libsasl2-dev libssl-dev && pip install -e /opt/ -r /opt/requirements.txt && pip install pycodestyle passlib coveralls && /usr/bin/python2 /opt/setup.py install
 VOLUME /etc/ldapcherry
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+
+RUN python setup.py
+VOLUME /etc/ldapcherry
+EXPOSE 80
+
+CMD ["ldapcherryd", "-c", "/etc/ldapcherry/ldapcherry.ini"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu
+FROM ubuntu:16.04
 
-RUN python setup.py
+ADD . .
+RUN apt update && apt install -y python3 python3-pip && pip3 install -e . -r requirements.txt && pip3 install pycodestyle passlib coveralls && /usr/bin/python3 setup.py
 VOLUME /etc/ldapcherry
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM ubuntu:16.04
 
 ADD . /opt/
 WORKDIR "/opt"
-RUN apt update && apt install -y python-dev python-pip libldap2-dev libsasl2-dev libssl-dev && pip install -e /opt/ -r /opt/requirements.txt && pip install pycodestyle passlib coveralls && /usr/bin/python2 /opt/setup.py install
+RUN apt update && apt install -y python-dev python-pip libldap2-dev libsasl2-dev libssl-dev
+RUN pip install -e /opt/ -r /opt/requirements.txt
+RUN pip install pycodestyle passlib coveralls
+RUN /usr/bin/python2 /opt/setup.py install
+
 VOLUME /etc/ldapcherry
 EXPOSE 80
 
-CMD ["ldapcherryd", "-c", "/etc/ldapcherry/ldapcherry.ini"]
+CMD ["/usr/bin/python2", "/opt/init.py"]

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Nice and simple application to manage users and groups in multiple directory ser
 :Dev:    `LdapCherry source code on GitHub <https://github.com/kakwa/ldapcherry>`_
 :PyPI:   `LdapCherry package on Pypi <http://pypi.python.org/pypi/ldapcherry>`_
 :License: MIT
-:Author:  Pierre-Francois Carpentier - copyright © 2016
+:Author:  Pierre-Francois Carpentier - copyright 2016
 
 ----
 

--- a/conf/ldapcherry.ini
+++ b/conf/ldapcherry.ini
@@ -32,9 +32,9 @@ request.show_tracebacks = False
 #  configuration to log to stdout   #
 #####################################
 ## logger stdout for access log
-#log.access_handler = 'stdout'
+log.access_handler = 'stdout'
 ## logger stdout for error and ldapcherry log
-#log.error_handler = 'stdout'
+log.error_handler = 'stdout'
 
 #####################################
 #  configuration to log in syslog   #
@@ -42,18 +42,18 @@ request.show_tracebacks = False
 # logger syslog for access log 
 #log.access_handler = 'syslog'
 ## logger syslog for error and ldapcherry log 
-log.error_handler = 'syslog'
+#log.error_handler = 'syslog'
 
 #####################################
 #  configuration to not log at all  #
 #####################################
 # logger none for access log 
-log.access_handler = 'none'
+#log.access_handler = 'none'
 # logger none for error and ldapcherry log 
 #log.error_handler = 'none'
 
 # log level
-log.level = 'info'
+log.level = 'debug'
 
 # session configuration
 # activate session

--- a/init.py
+++ b/init.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python2
+
+import os
+import sys
+
+#
+# This script sets up the ldapcherry config files through environment variables that are passed at
+# startup time.
+#
+
+ldapcherry_ini_settings = {
+    'SERVER_SOCKET_HOST': '0.0.0.0',
+    'SERVER_SOCKET_PORT': '80',
+    'SERVER_THREAD_POOL': '0',
+    'LOG_ACCESS_HANDLER': 'stdout',
+    'LOG_ERROR_HANDLER': 'stdout',
+    'LOG_LEVEL': '',
+    'LDAP_DISPLAY_NAME': 'My LDAP Directory',
+    'LDAP_URI': '',
+    'LDAP_CA': '',
+    'LDAP_STARTTLS': '',
+    'LDAP_CHECKCERT': '',
+    'LDAP_BINDDN': '',
+    'LDAP_PASSWORD': '',
+    'LDAP_TIMEOUT': '1',
+    'LDAP_GROUPDN': 'group',
+    'LDAP_USERDN': 'people',
+    'LDAP_USER_FILTER_TMPL': '',
+    'LDAP_GROUP_FILTER_TMPL': '',
+    'LDAP_SEARCH_FILTER_TMPL': '',
+    'LDAP_OBJECTCLASSES': '',
+    'LDAP_DN_USER_ATTR': '',
+    'AD_DISPLAY_NAME': '',
+    'AD_DOMAIN': '',
+    'AD_LOGIN': '',
+    'AD_PASSWORD': '',
+    'AD_URI': '',
+    'AD_CA': '',
+    'AD_STARTTLS': '',
+    'AD_CHECKCERT': ''
+}
+
+with open('/etc/ldapcherry/ldapcherry.ini', 'r') as file:
+    filelines = file.readlines()
+
+for setting in ldapcherry_ini_settings:
+    # Replace the instances of the key with the value of the env var or the
+    # default
+    setting_key = setting.replace('_', '.', 1).lower()
+    setting_val = os.getenv(setting, ldapcherry_ini_settings[setting])
+    if (any(line.startswith(setting_key) for line in filelines)
+            and ldapcherry_ini_settings[setting] != ''):
+        # We know that it is defined somewhere, so we don't want to uncomment
+        # any of the commented-out lines to replace it
+        indeces = [idx for idx, elem in enumerate(filelines)
+                   if elem.startswith(setting_key)]
+        # Exit if there are more than one instance defined
+        if len(indeces) != 1:
+            sys.exit()
+        filelines[indeces[0]] = "{0} = '{1}'\n".format(setting_key, setting_val)
+    elif (any(line.startswith('#' + setting_key) for line in filelines)
+            and ldapcherry_ini_settings[setting] != ''):
+        # We know that it is defined somewhere, but behind a comment. We will
+        # just change the first instance of it to the value that we want.
+        # We also know that it isn't defined anywhere due to the earlier test.
+        indeces = [idx for idx, elem in enumerate(filelines)
+                   if elem.startswith("#" + setting_key)]
+        filelines[indeces[0]] = "{0} = '{1}'\n".format(setting_key, setting_val)
+    else:
+        # It is not defined anywhere
+        continue
+
+# Write the file out again
+with open('/etc/ldapcherry/ldapcherry.ini', 'w') as file:
+    for fileline in filelines:
+        file.write("{}".format(fileline))
+
+os.system("/usr/local/bin/ldapcherryd -c /etc/ldapcherry/ldapcherry.ini -D")

--- a/init.py
+++ b/init.py
@@ -4,10 +4,13 @@ import os
 import sys
 
 #
-# This script sets up the ldapcherry config files through environment variables that are passed at
-# startup time.
+# This script sets up the ldapcherry config files through environment variables
+# that are passed at startup time.
 #
 
+# TODO: Add the rest of the options
+# TODO: Make some of these required, and some optional. How to fail when
+# they're not provided?
 ldapcherry_ini_settings = {
     'SERVER_SOCKET_HOST': '0.0.0.0',
     'SERVER_SOCKET_PORT': '80',
@@ -57,7 +60,13 @@ for setting in ldapcherry_ini_settings:
         # Exit if there are more than one instance defined
         if len(indeces) != 1:
             sys.exit()
-        filelines[indeces[0]] = "{0} = '{1}'\n".format(setting_key, setting_val)
+        if any(not char.isdigit() for char in setting_val):
+            # Make sure none of these are digits if it's going to be quoted
+            filelines[indeces[0]] = "{0} = '{1}'\n".format(setting_key,
+                                                           setting_val)
+        else:
+            filelines[indeces[0]] = "{0} = {1}\n".format(setting_key,
+                                                         setting_val)
     elif (any(line.startswith('#' + setting_key) for line in filelines)
             and ldapcherry_ini_settings[setting] != ''):
         # We know that it is defined somewhere, but behind a comment. We will

--- a/init.py
+++ b/init.py
@@ -74,7 +74,8 @@ for setting in ldapcherry_ini_settings:
         # We also know that it isn't defined anywhere due to the earlier test.
         indeces = [idx for idx, elem in enumerate(filelines)
                    if elem.startswith("#" + setting_key)]
-        filelines[indeces[0]] = "{0} = '{1}'\n".format(setting_key, setting_val)
+        filelines[indeces[0]] = "{0} = '{1}'\n".format(setting_key,
+                                                       setting_val)
     else:
         # It is not defined anywhere
         continue
@@ -84,4 +85,4 @@ with open('/etc/ldapcherry/ldapcherry.ini', 'w') as file:
     for fileline in filelines:
         file.write("{}".format(fileline))
 
-os.system("/usr/local/bin/ldapcherryd -c /etc/ldapcherry/ldapcherry.ini -D")
+os.system("/usr/local/bin/ldapcherryd -c /etc/ldapcherry/ldapcherry.ini")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-CherryPy>=3.0.0
+CherryPy==17.3.0
 PyYAML
 Mako
 python-ldap
+more-itertools<6.0.0


### PR DESCRIPTION
The environment is set up in the Dockerfile. The `/etc/ldapcherry/ldapcherry.ini` file is able to be either used regularly (which is exposed as a volume) or configured with environment variables that are passed to the container at runtime. This is done using the `init.py` script, which kicks off the main `ldapcherryd` process after setting up the conf file.

This is all done with python2, with an eye to migrating it to python3 when the application changes have been made.